### PR TITLE
update MTQ; fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cmake ../ -DBOOST_ROOT=PATH_TO_YOUR_BOOST_ROOT_DIR -DCMAKE_BUILD_TYPE=Release &&
 make
 ```
 
-    Executables will be saved in directory trim_isoseq_polyA/bin.
+    Executable `trim_isoseq_polyA` will be saved in directory trim_isoseq_polyA/bin.
     Please replace PATH_TO_YOUR_BOOST_ROOT_DIR with your own boost root directory.
     e.g., -DBOOST_ROOT=~/mylib/boost/boost_1_60_0/
 
@@ -32,20 +32,20 @@ make && make test
 ```
 
 ## Usage
-To process Iso-Seq
+To process Iso-Seq `classfy` output
 ```bash
-trim_isoseq_poly -i isoseq.flnc.fa -t 8 > isoseq.flnc.atrim.fa 2> isoseq.flnc.atrim.log
+trim_isoseq_polyA -i isoseq.flnc.fa -t 8 > isoseq.flnc.atrim.fa 2> isoseq.flnc.atrim.log
 ```
 
 To process generic fasta files
 ```bash
-trim_isoseq_poly -i input.fa -t 8 -G > input.atrim.fa 2> input.atrim.log
+trim_isoseq_polyA -i input.fa -t 8 -G > input.atrim.fa 2> input.atrim.log
 ```
-`.atrim.fa` file contain the fasta entries with polyA trimmed, based on a default HMM model trained with PacBio data.
+`input.atrim.fa` file contain the fasta entries with polyA trimmed, based on a default HMM model trained with PacBio data.
 
-`.atrim.fa` is a tab file with length of polyA been trimmed.
+`input.atrim.log` is a tab file with length of polyA been trimmed.
 
-To visualize polyA
+To visualize polyA (colored red when visualized by `cat`)
 ```bash
-trim_isoseq_poly -i isoseq.flnc.fa -t 8 -c 2>/dev/null
+trim_isoseq_polyA -i isoseq.flnc.fa -t 8 -c 2>/dev/null
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,31 +1,31 @@
 include_directories(
-    .
-    ${Boost_INCLUDE_DIRS}
-    ${ZLIB_INCLUDE_DIRS}
+        .
+        ${Boost_INCLUDE_DIRS}
+        ${ZLIB_INCLUDE_DIRS}
 )
 
 # source files
 set(LIB_SOURCE_FILES
-    char_traits.hpp
-    fasta.hpp
-    fastq.hpp
-    format.hpp
-    hmm_model.cpp
-    hmm_model.hpp
-    hmm_utilities.h
-    kernel_color.h
-    matrix.hpp
-    polyA_hmm_model.cpp
-    polyA_hmm_model.hpp
-    quality.hpp
-    sequence.hpp
-    type_policy.h
-)
+        char_traits.hpp
+        fasta.hpp
+        fastq.hpp
+        format.hpp
+        hmm_model.cpp
+        hmm_model.hpp
+        hmm_utilities.h
+        kernel_color.h
+        matrix.hpp
+        polyA_hmm_model.cpp
+        polyA_hmm_model.hpp
+        quality.hpp
+        sequence.hpp
+        type_policy.h
+        )
 
 set(EXE_SOURCE_FILES
-    ${LIB_SOURCE_FILES}
-    main.cpp
-)
+        ${LIB_SOURCE_FILES}
+        main.cpp
+        )
 
 # CXX and LINKER FLAGS
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TrimIsoseqPolyA_CXX_FLAGS}")
@@ -33,27 +33,27 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${TrimIsoseqPolyA_EXE_LINK
 
 add_library(trima ${LIB_SOURCE_FILES})
 set_target_properties(trima PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
-    RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
-    LIBRARY_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
-)
+        ARCHIVE_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
+        RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
+        LIBRARY_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
+        )
 
 add_executable(trim_isoseq_polyA ${EXE_SOURCE_FILES})
 set_target_properties(trim_isoseq_polyA PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_BinDir}
-)
+        RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_BinDir}
+        )
 
 if (NOT APPLE)
     set(MY_LIBRT -lrt)
-else()
-endif()
+else ()
+endif ()
 
 message(status "Boost_LIBRARIES: " ${Boost_LIBRARIES})
 
 target_link_libraries(trim_isoseq_polyA
-    ${Boost_LIBRARIES}
-    ${ZLIB_LIBRARIES}
-    ${BZIP2_LIBRARIES} 
-    ${CMAKE_THREAD_LIBS_INIT}
-    #${MY_LIBRT}
-)
+        ${Boost_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+        ${BZIP2_LIBRARIES}
+        ${CMAKE_THREAD_LIBS_INIT}
+        #${MY_LIBRT}
+        )

--- a/src/fasta.hpp
+++ b/src/fasta.hpp
@@ -46,19 +46,24 @@
 #include "sequence.hpp"
 #include "type_policy.h"
 
-template <class T = caseInsensitiveString>
-struct Fasta : public Sequence<T> {
+template<class T = caseInsensitiveString>
+struct Fasta: public Sequence<T>
+{
     using seq_type = Sequence<T>;
-    std::string name_; // sequnece can take different representation such as char*, std::string or twoBits; name has to be string
+    using iterator = FormatReaderIter<Fasta>;
+    std::string
+        name_; // sequence can take different representation such as char*, std::string or twoBits; name has to be string
 };
 
 /* reading policy */
-template <class T>
-struct read_policy<Fasta<T> > {
+template<class T>
+struct read_policy<Fasta<T> >
+{
     using string_type = T;
     using fasta_type = Fasta<T>;
+
     // reading policy for fasta in the ifstream
-    static fasta_type read(std::istream* ins)
+    static fasta_type read(std::istream *ins)
     {
         fasta_type fa{};
         if (ins->peek() != '>' || ins->eof()) {
@@ -72,29 +77,32 @@ struct read_policy<Fasta<T> > {
             do {
                 ins->clear();
                 ins->getline(buffer, bufsize, '\n');
-                fa.seq_ += buffer;
+                fa.seq_.append(buffer);
             } while ((bufsize == ins->gcount() + 1) && (ins->rdstate() == std::ios::failbit));
         }
         return fa;
     }
 };
 
-template <class T>
-struct FastaSupported {
+template<class T>
+struct FastaSupported
+{
     const static bool value = false;
 };
 
-template <>
-struct FastaSupported<std::string> {
+template<>
+struct FastaSupported<std::string>
+{
     const static bool value = true;
 }; // currently string is supported
 
-template <>
-struct FastaSupported<caseInsensitiveString> {
+template<>
+struct FastaSupported<caseInsensitiveString>
+{
     const static bool value = true;
 }; // currently caseInsensitiveString is supported
 
-template <class T = caseInsensitiveString, class = typename std::enable_if<FastaSupported<T>::value>::type>
+template<class T = caseInsensitiveString, class = typename std::enable_if<FastaSupported<T>::value>::type>
 using FastaReader = FormatReader<Fasta<T> >;
 
 #endif

--- a/src/fastq.hpp
+++ b/src/fastq.hpp
@@ -46,21 +46,24 @@
 #include "sequence.hpp"
 #include "type_policy.h"
 
-template <class T = caseInsensitiveString>
-struct Fastq : public Sequence<T> {
+template<class T = caseInsensitiveString>
+struct Fastq: public Sequence<T>
+{
     using seq_type = Sequence<T>;
+    using iterator = FormatReaderIter<Fastq>;
     std::string name_;
     std::string quality_;
 };
 
 /* reading policy */
-template <class T>
-struct read_policy<Fastq<T> > {
+template<class T>
+struct read_policy<Fastq<T> >
+{
     using traits_type = typename T::traits_type;
     using string_type = T;
     using fastq_type  = Fastq<T>;
     // reading policy for fasta in the ifstream
-    static fastq_type read(std::istream* ins)
+    static fastq_type read(std::istream *ins)
     {
         fastq_type fq{};
         if (ins->peek() != '@' || ins->eof()) {
@@ -69,14 +72,14 @@ struct read_policy<Fastq<T> > {
         ins->get(); // consume '@'
         std::getline(*ins, fq.name_); // read name, which is always std::string
         char c;
-        while(true) {
+        while (true) {
             ins->get(c);
-            if(c == '\n') break;
+            if (c == '\n') break;
             fq.seq_ += c;
         }
         ins->ignore(std::numeric_limits<int>::max(), '\n');
         std::getline(*ins, fq.quality_);
-        if(fq.seq_.size() != fq.quality_.size()) {
+        if (fq.seq_.size() != fq.quality_.size()) {
             fprintf(stderr, "[warning] the length of sequence and quality does not match for %s\n",
                     fq.name_.c_str());
         }
@@ -84,22 +87,25 @@ struct read_policy<Fastq<T> > {
     }
 };
 
-template <class T>
-struct FastqSupported {
+template<class T>
+struct FastqSupported
+{
     const static bool value = false;
 };
 
-template <>
-struct FastqSupported<std::string> {
+template<>
+struct FastqSupported<std::string>
+{
     const static bool value = true;
 }; // currently string is supported
 
-template <>
-struct FastqSupported<caseInsensitiveString> {
+template<>
+struct FastqSupported<caseInsensitiveString>
+{
     const static bool value = true;
 }; // currently caseInsensitiveString is supported
 
-template <class T = caseInsensitiveString, class = typename std::enable_if<FastqSupported<T>::value>::type>
+template<class T = caseInsensitiveString, class = typename std::enable_if<FastqSupported<T>::value>::type>
 using FastqReader = FormatReader<Fastq<T> >;
 
 #endif

--- a/src/format.hpp
+++ b/src/format.hpp
@@ -50,21 +50,21 @@
 #include <boost/iostreams/filter/bzip2.hpp>
 #include "type_policy.h"
 
-template <class T>
+template<class T>
 class FormatReader;
 
 /* define iterator */
-template <class T>
-class FormatReaderIter : public boost::iterator_facade<FormatReaderIter<T>, T, std::input_iterator_tag> {
+template<class T>
+class FormatReaderIter: public boost::iterator_facade<FormatReaderIter<T>, T, std::input_iterator_tag>
+{
 public:
     // default constructr, meant to be called by FormatReader.end();
     FormatReaderIter()
-        : fp_(nullptr)
-        , data_{ new T{} }
+        : fp_(nullptr), data_{new T{}}
     {
     }
 
-    explicit FormatReaderIter(boost::iostreams::filtering_istream* fp)
+    explicit FormatReaderIter(boost::iostreams::filtering_istream *fp)
         : fp_(fp)
     {
         this->increment();
@@ -77,42 +77,44 @@ private:
 
     void increment()
     {
-        data_.reset(new T{ read_policy<T>::read(fp_) });
+        data_.reset(new T{read_policy<T>::read(fp_)});
         // the policy should return default T{} to indicate EOF or ill-formated file
     }
 
-    bool equal(const FormatReaderIter& other) const
+    bool equal(const FormatReaderIter &other) const
     {
         return *data_ == *(other.data_); // only called by != ...end()
     }
 
-    T& dereference() const
+    T &dereference() const
     {
         return *data_;
     }
 
-    boost::iostreams::filtering_istream* fp_ = nullptr;
+    boost::iostreams::filtering_istream *fp_ = nullptr;
     std::shared_ptr<T> data_ = nullptr;
-}; /* end of iterator definition */
+};
+/* end of iterator definition */
 
-template <class T>
-class FormatReader {
+template<class T>
+class FormatReader
+{
 public:
     using iterator = FormatReaderIter<T>;
     using const_iterator = const iterator;
 
-    explicit FormatReader(const std::string& file_name)
+    explicit FormatReader(const std::string &file_name)
     {
-        std::istream* p_ist_in{ &std::cin };
+        std::istream *p_ist_in{&std::cin};
         if (file_name != "stdin" && file_name != "-") {
             if (access(file_name.c_str(), R_OK) != 0) {
                 fprintf(stderr, "error, cannot read file %s. Please double check.\n", file_name.c_str());
                 exit(EXIT_FAILURE);
             }
-            p_ist_in = new std::ifstream{ file_name };
+            p_ist_in = new std::ifstream{file_name};
             char magic_number[4] = "\0\0\0";
             p_ist_in->get(magic_number, 3);
-            if (magic_number[0] == '\037' && magic_number[1] == (char)'\213') {
+            if (magic_number[0] == '\037' && magic_number[1] == (char) '\213') {
                 ins_.push(boost::iostreams::gzip_decompressor());
             }
             else if (magic_number[0] == 'B' && magic_number[1] == 'Z') {
@@ -128,11 +130,12 @@ public:
         ins_.push(*p_ist_in);
     }
 
-    ~FormatReader() {}
+    ~FormatReader()
+    { }
 
     iterator begin()
     {
-        return iterator{ &ins_ };
+        return iterator{&ins_};
     }
 
     iterator end()

--- a/src/hmm_model.cpp
+++ b/src/hmm_model.cpp
@@ -36,31 +36,22 @@
 // Author: Bo Han
 #include "hmm_model.hpp"
 
-HmmModeBase::HmmModeBase(int sta, int sym) 
-    : no_states_(sta)
-    , no_symbol_(sym)
-    , init_(sta, 1)
-    , tran_(sta, sta)
-    , emit_(sta, sym)
+HmmModeBase::HmmModeBase(int sta, int sym)
+    : no_states_(sta), no_symbol_(sym), init_(sta, 1), tran_(sta, sta), emit_(sta, sym)
 { }
 
-HmmModeBase::HmmModeBase(const HmmModeBase& other)
-    : no_states_(other.no_states_)
-    , no_symbol_(other.no_symbol_)
-    , init_(other.init_)
-    , tran_(other.tran_)
-    , emit_(other.emit_)
+HmmModeBase::HmmModeBase(const HmmModeBase &other)
+    : no_states_(other.no_states_), no_symbol_(other.no_symbol_), init_(other.init_), tran_(other.tran_), emit_(other
+                                                                                                                    .emit_)
 { }
 
-HmmModeBase::HmmModeBase(HmmModeBase&& other)
-    : no_states_(other.no_states_)
-    , no_symbol_(other.no_symbol_)
-    , init_(std::move(other.init_))
-    , tran_(std::move(other.tran_))
-    , emit_(std::move(other.emit_))
+HmmModeBase::HmmModeBase(HmmModeBase &&other)
+    : no_states_(other.no_states_), no_symbol_(other.no_symbol_), init_(std::move(other.init_)), tran_(std::move(other
+                                                                                                                     .tran_)), emit_(
+    std::move(other.emit_))
 { }
 
-HmmModeBase& HmmModeBase::operator=(HmmModeBase&& other)
+HmmModeBase &HmmModeBase::operator=(HmmModeBase &&other)
 {
     if (this != &other) {
         no_states_ = other.no_states_;
@@ -72,8 +63,10 @@ HmmModeBase& HmmModeBase::operator=(HmmModeBase&& other)
     return *this;
 }
 
-size_t HmmModeBase::states() const { return no_states_; }
-size_t HmmModeBase::symbols() const { return no_symbol_; }
+size_t HmmModeBase::states() const
+{ return no_states_; }
+size_t HmmModeBase::symbols() const
+{ return no_symbol_; }
 
 HmmModeBase::reference HmmModeBase::initialProb(size_t i)
 {
@@ -116,7 +109,7 @@ void HmmModeBase::emitProb(size_t i, size_t j, value_type v)
 }
 
 //virtual bool HmmModeBase::read(const std::string& filename)
-bool HmmModeBase::read(const std::string& filename)
+bool HmmModeBase::read(const std::string &filename)
 { /* serialization is overkill */
     std::ifstream ifs;
     try {
@@ -151,7 +144,7 @@ bool HmmModeBase::read(const std::string& filename)
 }
 
 //virtual bool HmmModeBase::write(const std::string& filename)
-bool HmmModeBase::write(const std::string& filename)
+bool HmmModeBase::write(const std::string &filename)
 {
     std::ofstream ofs;
     try {

--- a/src/hmm_model.hpp
+++ b/src/hmm_model.hpp
@@ -40,29 +40,31 @@
 #include "matrix.hpp"
 #include <fstream>
 
-class HmmModeBase {
+class HmmModeBase
+{
     // type
 protected:
     using value_type    = double;
     using matrix_type   = Matrix<value_type>;
-    using pointer       = value_type*;
+    using pointer       = value_type *;
     using const_pointer = const pointer;
-    using reference     = value_type&;
+    using reference     = value_type &;
 
     // methods
 public:
     explicit HmmModeBase(int sta = 0, int sym = 0);
 
-    virtual ~HmmModeBase() {}
+    virtual ~HmmModeBase()
+    { }
 
-    HmmModeBase(const HmmModeBase& other);
-        
-    HmmModeBase(HmmModeBase&& other);
-        
-    HmmModeBase& operator=(const HmmModeBase&) = delete;
+    HmmModeBase(const HmmModeBase &other);
 
-    HmmModeBase& operator=(HmmModeBase&& other);
-    
+    HmmModeBase(HmmModeBase &&other);
+
+    HmmModeBase &operator=(const HmmModeBase &) = delete;
+
+    HmmModeBase &operator=(HmmModeBase &&other);
+
     size_t states() const;
     size_t symbols() const;
 
@@ -78,10 +80,10 @@ public:
 
     void emitProb(size_t i, size_t j, value_type v);
 
-    virtual bool read(const std::string& filename);
+    virtual bool read(const std::string &filename);
 
-    virtual bool write(const std::string& filename);
-    
+    virtual bool write(const std::string &filename);
+
     // data
 protected:
     size_t no_states_;

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -47,47 +47,45 @@
 #include <utility> // for swap
 #include <initializer_list>
 
-template <class T>
-class Matrix {
+template<class T>
+class Matrix
+{
     // type
 public:
     using value_type    = T;
-    using pointer       = T*;
-    using const_pointer = const T*;
-    using reference     = T&;
+    using pointer       = T *;
+    using const_pointer = const T *;
+    using reference     = T &;
 
     explicit Matrix(size_t r = 0, size_t c = 0)
-        : row_(r)
-        , col_(c)
-        , data_(nullptr)
+        : row_(r), col_(c), data_(nullptr)
     {
         if (r > 0 && c > 0)
-            data_ = (pointer)malloc(sizeof(value_type) * row_ * col_);
+            data_ = (pointer) malloc(sizeof(value_type) * row_ * col_);
     }
 
-    virtual ~Matrix() { free(data_); }
+    virtual ~Matrix()
+    { free(data_); }
 
-    Matrix(const Matrix& other)
-        : row_(other.row_)
-        , col_(other.col_)
+    Matrix(const Matrix &other)
+        : row_(other.row_), col_(other.col_)
     {
-        if(data_ != nullptr) {
+        if (data_ != nullptr) {
             free(data_);
             data_ = nullptr;
         }
-        data_ = (pointer)malloc(sizeof(value_type) * row_ * col_);
+        data_ = (pointer) malloc(sizeof(value_type) * row_ * col_);
         memcpy(data_, other.data_, sizeof(value_type) * row_ * col_);
     }
 
-    Matrix(Matrix&& other)
-        : row_(other.row_)
-        , col_(other.col_)
+    Matrix(Matrix &&other)
+        : row_(other.row_), col_(other.col_)
     {
         std::swap(data_, other.data_);
     }
 
-    Matrix& operator=(const Matrix&) = delete;
-    Matrix& operator=(Matrix&& other)
+    Matrix &operator=(const Matrix &) = delete;
+    Matrix &operator=(Matrix &&other)
     {
         if (this != &other) {
             row_ = other.row_;
@@ -97,7 +95,7 @@ public:
         return *this;
     }
 
-    Matrix& operator=(std::initializer_list<value_type> values)
+    Matrix &operator=(std::initializer_list<value_type> values)
     {
         assert(row_ * col_ >= values.size());
         int i = 0;
@@ -107,9 +105,12 @@ public:
         return *this;
     }
 
-    size_t row() const { return row_; }
-    size_t col() const { return col_; }
-    size_t size() const { return row_ * col_; }
+    size_t row() const
+    { return row_; }
+    size_t col() const
+    { return col_; }
+    size_t size() const
+    { return row_ * col_; }
 
     reference operator()(size_t i, size_t j) const
     {
@@ -142,23 +143,23 @@ public:
         row_ = r;
         col_ = c;
         if (data_ == nullptr)
-            data_ = (pointer)malloc(row_ * col_ * sizeof(value_type));
+            data_ = (pointer) malloc(row_ * col_ * sizeof(value_type));
         else {
-            void* t = realloc(data_, row_ * col_ * sizeof(value_type));
+            void *t = realloc(data_, row_ * col_ * sizeof(value_type));
             assert(t != nullptr);
-            data_ = (pointer)t;
+            data_ = (pointer) t;
         }
     }
 
-    template <class TFunc, class... TArgs>
-    Matrix& apply(TFunc&& func, TArgs&&... args)
+    template<class TFunc, class... TArgs>
+    Matrix &apply(TFunc &&func, TArgs &&... args)
     {
         static_assert(
             std::is_same<value_type, decltype(std::forward<TFunc>(func)(
-                                         value_type{},
-                                         std::forward<TArgs...>(args)...))>::value,
+                value_type{},
+                std::forward<TArgs...>(args)...))>::value,
             "the callable argument of apply should takes value_type as the first "
-            "argument and have value_type as the return type");
+                "argument and have value_type as the return type");
         for (size_t i = 0; i < row_ * col_; ++i) {
             data_[i] = std::forward<TFunc>(func)(data_[i], std::forward<TArgs...>(args)...);
             // TODO: optimize with SIMD
@@ -166,7 +167,7 @@ public:
         return *this;
     }
 
-    Matrix& operator=(value_type val)
+    Matrix &operator=(value_type val)
     {
         // TODO: optimize this function with memset if std::is_same<std::is_integral<value_type>::type, std::true_type>::value
         std::fill_n(data_, row_ * col_, val);
@@ -175,36 +176,44 @@ public:
         // val);
     }
 
-    Matrix& operator+=(value_type val)
+    Matrix &operator+=(value_type val)
     {
         return apply(
-            [&](value_type a, value_type b) -> value_type { return a
-                                                                + b; }, val);
+            [&](value_type a, value_type b) -> value_type {
+                return a
+                    + b;
+            }, val);
     }
 
-    Matrix& operator-=(value_type val)
+    Matrix &operator-=(value_type val)
     {
         return apply(
-            [&](value_type a, value_type b) -> value_type { return a
-                                                                - b; }, val);
+            [&](value_type a, value_type b) -> value_type {
+                return a
+                    - b;
+            }, val);
     }
 
-    Matrix& operator*=(value_type val)
+    Matrix &operator*=(value_type val)
     {
         return apply(
-            [&](value_type a, value_type b) -> value_type { return a
-                                                                * b; }, val);
+            [&](value_type a, value_type b) -> value_type {
+                return a
+                    * b;
+            }, val);
     }
 
-    Matrix& operator/=(value_type val)
+    Matrix &operator/=(value_type val)
     {
         assert(val != 0);
         return apply(
-            [&](value_type a, value_type b) -> value_type { return a
-                                                                / b; }, val);
+            [&](value_type a, value_type b) -> value_type {
+                return a
+                    / b;
+            }, val);
     }
 
-    Matrix& log2()
+    Matrix &log2()
     {
         return apply([&](value_type a) -> value_type {
             assert(a > 0);
@@ -236,8 +245,8 @@ public:
     }
 
     /* most generic */
-    template <class U>
-    bool equal(const Matrix<U>& rhs) const
+    template<class U>
+    bool equal(const Matrix<U> &rhs) const
     {
         if (row_ != rhs.row() || col_ != rhs.col())
             return false;
@@ -251,7 +260,7 @@ public:
     }
 
     /* same type, potential optimization with memcmp */
-    bool equal(const Matrix<value_type>& rhs) const
+    bool equal(const Matrix<value_type> &rhs) const
     {
         if (row_ != rhs.row_ || col_ != rhs.col_)
             return false;
@@ -259,8 +268,8 @@ public:
     }
 
 protected:
-    bool equalAux_(const Matrix<value_type>& rhs,
-        std::true_type /*is integral*/) const
+    bool equalAux_(const Matrix<value_type> &rhs,
+                   std::true_type /*is integral*/) const
     {
         if (memcmp(data_, rhs.data_, sizeof(value_type) * row_ * col_) == 0)
             return true;
@@ -268,8 +277,8 @@ protected:
             return false;
     }
 
-    bool equalAux_(const Matrix<value_type>& rhs,
-        std::false_type /*is not integral*/) const
+    bool equalAux_(const Matrix<value_type> &rhs,
+                   std::false_type /*is not integral*/) const
     {
         for (size_t i = 0; i < row_; ++i) {
             for (size_t j = 0; j < col_; ++j) {
@@ -286,14 +295,14 @@ protected:
     pointer data_ = nullptr;
 };
 
-template <class T, class U>
-bool operator==(const Matrix<T>& lhs, const Matrix<U>& rhs)
+template<class T, class U>
+bool operator==(const Matrix<T> &lhs, const Matrix<U> &rhs)
 {
     return lhs.equal(rhs);
 }
 
-template <class T, class U>
-bool operator!=(const Matrix<T>& lhs, const Matrix<U>& rhs)
+template<class T, class U>
+bool operator!=(const Matrix<T> &lhs, const Matrix<U> &rhs)
 {
     return !lhs.equal(rhs);
 }

--- a/src/polyA_hmm_model.cpp
+++ b/src/polyA_hmm_model.cpp
@@ -43,23 +43,17 @@ PolyAHmmMode::PolyAHmmMode()
     : _base(nStates, nSymbol)
 { }
 
-PolyAHmmMode::PolyAHmmMode(const PolyAHmmMode& other)
-    : _base(other)
-    , forw_(other.forw_)
-    , back_(other.back_)
-    , post_(other.post_)
-    , path_(other.path_)
+PolyAHmmMode::PolyAHmmMode(const PolyAHmmMode &other)
+    : _base(other), forw_(other.forw_), back_(other.back_), post_(other.post_), path_(other.path_)
 { }
 
-PolyAHmmMode::PolyAHmmMode(PolyAHmmMode&& other)
-    : _base(std::move(other))
-    , forw_(std::move(other.forw_))
-    , back_(std::move(other.back_))
-    , post_(std::move(other.post_))
-    , path_(std::move(other.path_))
+PolyAHmmMode::PolyAHmmMode(PolyAHmmMode &&other)
+    : _base(std::move(other)), forw_(std::move(other.forw_)), back_(std::move(other.back_)), post_(std::move(other
+                                                                                                                 .post_)), path_(
+    std::move(other.path_))
 { }
 
-PolyAHmmMode& PolyAHmmMode::operator=(PolyAHmmMode&& other)
+PolyAHmmMode &PolyAHmmMode::operator=(PolyAHmmMode &&other)
 {
     if (this != &other) {
         _base::operator=(std::move(other));
@@ -72,7 +66,7 @@ PolyAHmmMode& PolyAHmmMode::operator=(PolyAHmmMode&& other)
 }
 
 //virtual bool PolyAHmmMode::read(const std::string& filename)
-bool PolyAHmmMode::read(const std::string& filename)
+bool PolyAHmmMode::read(const std::string &filename)
 {
     bool ret = _base::read(filename);
     // any chance of overwriting
@@ -86,7 +80,7 @@ bool PolyAHmmMode::read(const std::string& filename)
 }
 
 //virtual bool PolyAHmmMode::write(const std::string& filename)
-bool PolyAHmmMode::write(const std::string& filename)
+bool PolyAHmmMode::write(const std::string &filename)
 {
     //		value_type t1 = tran_(States::POLYA, States::POLYA);
     //		value_type t2 = tran_(States::NONPOLYA, States::POLYA);

--- a/src/polyA_hmm_model.hpp
+++ b/src/polyA_hmm_model.hpp
@@ -44,7 +44,8 @@
 #include "hmm_model.hpp"
 #include "hmm_utilities.h"
 
-class PolyAHmmMode : public HmmModeBase {
+class PolyAHmmMode: public HmmModeBase
+{
     // types
 private:
     using _base = HmmModeBase;
@@ -61,70 +62,74 @@ public:
     constexpr static size_t nStates = 2;
     constexpr static size_t nSymbol = 4;
 
-    enum States : int {
-        POLYA    = 0,
+    enum States: int
+    {
+        POLYA = 0,
         NONPOLYA = 1,
-        UNKNOWN  = 2
+        UNKNOWN = 2
     };
     // methods
 public:
     PolyAHmmMode();
 
-    virtual ~PolyAHmmMode() {}
+    virtual ~PolyAHmmMode()
+    { }
 
-    PolyAHmmMode(const PolyAHmmMode& other);
+    PolyAHmmMode(const PolyAHmmMode &other);
 
-    PolyAHmmMode(PolyAHmmMode&& other);
+    PolyAHmmMode(PolyAHmmMode &&other);
 
-    PolyAHmmMode& operator=(const PolyAHmmMode&) = delete;
+    PolyAHmmMode &operator=(const PolyAHmmMode &) = delete;
 
-    PolyAHmmMode& operator=(PolyAHmmMode&& other);
+    PolyAHmmMode &operator=(PolyAHmmMode &&other);
 
-    virtual bool read(const std::string& filename);
-    
-    virtual bool write(const std::string& filename);
-    
+    virtual bool read(const std::string &filename);
+
+    virtual bool write(const std::string &filename);
+
 /* evaluating algorithms */
 public:
-    template <class TSequence>
-    const matrix_type& calculateForward(const TSequence&) const;
+    template<class TSequence>
+    const matrix_type &calculateForward(const TSequence &) const;
 
-    template <class TIter>
-    const matrix_type& calculateForward(TIter, size_t) const;
+    template<class TIter>
+    const matrix_type &calculateForward(TIter, size_t) const;
 
-    template <class TSequence>
-    const matrix_type& calculateBackward(const TSequence&) const;
+    template<class TSequence>
+    const matrix_type &calculateBackward(const TSequence &) const;
 
-    template <class TIter>
-    const matrix_type& calculateBackward(TIter, size_t) const;
+    template<class TIter>
+    const matrix_type &calculateBackward(TIter, size_t) const;
 
-    template <class TSequence>
-    const matrix_type& calculatePosterior(const TSequence&) const;
+    template<class TSequence>
+    const matrix_type &calculatePosterior(const TSequence &) const;
 
 /* decoding algorithms */
 public:
-    template <class TSequence>
-    const path_type& calculateVirtabi(const TSequence&) const;
+    template<class TSequence>
+    const path_type &calculateVirtabi(const TSequence &) const;
 
-    template <class TIter>
-    const path_type& calculateVirtabi(TIter, size_t) const;
+    template<class TIter>
+    const path_type &calculateVirtabi(TIter, size_t) const;
 
 /* training algorithms */
 public:
     // estimate init_, emit_ & tran_ by taking a bunch of sequences
-    template <class TSeqIterator>
-    void maximumLikelihoodEstimation(TSeqIterator b_polya, TSeqIterator e_polya, TSeqIterator b_nonpolya, TSeqIterator e_nonpolya);
+    template<class TSeqIterator>
+    void maximumLikelihoodEstimation
+        (TSeqIterator b_polya, TSeqIterator e_polya, TSeqIterator b_nonpolya, TSeqIterator e_nonpolya);
 
 protected:
-    template <class TSeqIterator>
-    std::pair<size_t, size_t> maximumLikelihoodEstimationAux_(TSeqIterator, TSeqIterator, std::underlying_type<States>::type);
+    template<class TSeqIterator>
+    std::pair<size_t, size_t>
+        maximumLikelihoodEstimationAux_(TSeqIterator, TSeqIterator, std::underlying_type<States>::type);
 
 // data
 protected:
     mutable matrix_type forw_;
     mutable matrix_type back_;
     mutable matrix_type post_;
-    mutable path_type   path_;
+    mutable path_type path_;
 };
 
 // -----------------------------------------------
@@ -132,7 +137,7 @@ protected:
 // answer the question: what is the most possible
 // state chain that generate a given sequence?
 // -----------------------------------------------
-template <class TIterator>
+template<class TIterator>
 auto PolyAHmmMode::calculateVirtabi(TIterator striter, size_t N) const -> const path_type &
 {
     matrix_type prob(no_states_, N);
@@ -181,8 +186,8 @@ auto PolyAHmmMode::calculateVirtabi(TIterator striter, size_t N) const -> const 
     return path_;
 }
 
-template <class TSequence>
-auto PolyAHmmMode::calculateVirtabi(const TSequence& seq) const -> const path_type &
+template<class TSequence>
+auto PolyAHmmMode::calculateVirtabi(const TSequence &seq) const -> const path_type &
 {
     size_t N = strsize<TSequence>::size(seq);
     return PolyAHmmMode::calculateVirtabi(std::begin(seq), N);
@@ -194,7 +199,7 @@ auto PolyAHmmMode::calculateVirtabi(const TSequence& seq) const -> const path_ty
 // sequence X(1)X(2)..X(i), given X(i) is
 // in state of k?
 // -----------------------------------------------
-template <class TIterator>
+template<class TIterator>
 auto PolyAHmmMode::calculateForward(TIterator striter, size_t N) const -> const matrix_type &
 {
     forw_.reSize(no_states_, N);
@@ -221,8 +226,8 @@ auto PolyAHmmMode::calculateForward(TIterator striter, size_t N) const -> const 
     return forw_;
 }
 
-template <class TSequence>
-auto PolyAHmmMode::calculateForward(const TSequence& seq) const -> const matrix_type &
+template<class TSequence>
+auto PolyAHmmMode::calculateForward(const TSequence &seq) const -> const matrix_type &
 {
     size_t N = strsize<TSequence>::size(seq);
     return PolyAHmmMode::calculateForward(std::begin(seq), N);
@@ -233,7 +238,7 @@ auto PolyAHmmMode::calculateForward(const TSequence& seq) const -> const matrix_
 // answer the question: what is the probability of
 // X(i+1)X(i+2)...X(l), given X(i) is in state k?
 // -----------------------------------------------
-template <class TIterator>
+template<class TIterator>
 auto PolyAHmmMode::calculateBackward(TIterator strriter, size_t N) const -> const matrix_type &
 {
     back_.reSize(no_states_, N);
@@ -261,8 +266,8 @@ auto PolyAHmmMode::calculateBackward(TIterator strriter, size_t N) const -> cons
     return back_;
 }
 
-template <class TSequence>
-auto PolyAHmmMode::calculateBackward(const TSequence& seq) const -> const matrix_type &
+template<class TSequence>
+auto PolyAHmmMode::calculateBackward(const TSequence &seq) const -> const matrix_type &
 {
     size_t N = strsize<TSequence>::size(seq);
     // no corespoding std::rbegin()
@@ -278,8 +283,8 @@ auto PolyAHmmMode::calculateBackward(const TSequence& seq) const -> const matrix
 // answer the question: what is the probability of X(i)
 // in state of k, given the sequence X(1)X(2)..X(i)..X(l)?
 // -----------------------------------------------
-template <class TSequence>
-auto PolyAHmmMode::calculatePosterior(const TSequence& seq) const -> const matrix_type &
+template<class TSequence>
+auto PolyAHmmMode::calculatePosterior(const TSequence &seq) const -> const matrix_type &
 {
     size_t N = strsize<TSequence>::size(seq);
     calculateForward(seq);
@@ -307,8 +312,11 @@ auto PolyAHmmMode::calculatePosterior(const TSequence& seq) const -> const matri
 // data with answer
 // -----------------------------------------------
 
-template <class TSeqIterator>
-void PolyAHmmMode::maximumLikelihoodEstimation(TSeqIterator b_polya, TSeqIterator e_polya, TSeqIterator b_nonpolya, TSeqIterator e_nonpolya)
+template<class TSeqIterator>
+void PolyAHmmMode::maximumLikelihoodEstimation(TSeqIterator b_polya,
+                                               TSeqIterator e_polya,
+                                               TSeqIterator b_nonpolya,
+                                               TSeqIterator e_nonpolya)
 {
     auto count_A = maximumLikelihoodEstimationAux_(b_polya, e_polya, States::POLYA);
     auto count_B = maximumLikelihoodEstimationAux_(b_nonpolya, e_nonpolya, States::NONPOLYA);
@@ -320,21 +328,23 @@ void PolyAHmmMode::maximumLikelihoodEstimation(TSeqIterator b_polya, TSeqIterato
     initialProb(States::NONPOLYA) = 1.0 - init_[States::POLYA];
 
     // transition probability, assuming geometric duration distribution
-    tran_(States::POLYA, States::POLYA)    = 1.0 - 1.0 / static_cast<value_type>(count_A.second);
+    tran_(States::POLYA, States::POLYA) = 1.0 - 1.0 / static_cast<value_type>(count_A.second);
     tran_(States::POLYA, States::NONPOLYA) = 1.0 - tran_(States::POLYA, States::POLYA);
 
     tran_(States::NONPOLYA, States::NONPOLYA) = 1.0 - 1.0 / static_cast<value_type>(count_B.second);
-    tran_(States::NONPOLYA, States::POLYA)    = 1.0 - tran_(States::NONPOLYA, States::NONPOLYA);
+    tran_(States::NONPOLYA, States::POLYA) = 1.0 - tran_(States::NONPOLYA, States::NONPOLYA);
 }
 
-template <class TSeqIterator>
-std::pair<size_t, size_t> PolyAHmmMode::maximumLikelihoodEstimationAux_(TSeqIterator b, TSeqIterator e, std::underlying_type<States>::type s)
+template<class TSeqIterator>
+std::pair<size_t, size_t> PolyAHmmMode::maximumLikelihoodEstimationAux_(TSeqIterator b,
+                                                                        TSeqIterator e,
+                                                                        std::underlying_type<States>::type s)
 { // s is POLYA(0) or NONPOLYA(1), init_[s], emit_(s, ?)
     if (b == e) {
         fprintf(stderr, "[ERROR] Invalid iterator, possible empty file\n");
         exit(EXIT_FAILURE);
     }
-    std::pair<size_t, size_t> ret{ 0, 0 }; // ret.first: # of entries; ret.second: # of nucleotide
+    std::pair<size_t, size_t> ret{0, 0}; // ret.first: # of entries; ret.second: # of nucleotide
     Matrix<int> new_emit(1, nSymbol);
     new_emit = 0;
     for (; b != e; ++b) {

--- a/src/sequence.hpp
+++ b/src/sequence.hpp
@@ -42,40 +42,43 @@
 
 using caseInsensitiveString = std::basic_string<char, CaseInsensitiveCharTrait<char>, std::allocator<char> >;
 
-template <>
-struct strsize<caseInsensitiveString> {
-    static size_t size(const caseInsensitiveString& s) { return s.size(); }
+template<>
+struct strsize<caseInsensitiveString>
+{
+    static size_t size(const caseInsensitiveString &s)
+    { return s.size(); }
 };
 
-template <class T = caseInsensitiveString>
-struct Sequence {
+template<class T = caseInsensitiveString>
+struct Sequence
+{
     // type
     using seq_type = T;
     // methods
     Sequence()
-        : seq_{ "" }
+        : seq_{""}
     {
     }
-    Sequence(const seq_type& other)
+    Sequence(const seq_type &other)
         : seq_(other)
     {
     }
     //    template<class Iter> Sequence(Iter a, Iter b) : seq_(a, b) { }
-    Sequence(const Sequence<T>& other)
+    Sequence(const Sequence<T> &other)
         : seq_(other.seq_)
     {
     }
-    Sequence(Sequence<T>&& other)
+    Sequence(Sequence<T> &&other)
         : seq_(std::move(other.seq_))
     {
     }
-    Sequence& operator=(const Sequence& other)
+    Sequence &operator=(const Sequence &other)
     {
         assert(this != &other);
         seq_ = other.seq_;
         return *this;
     }
-    Sequence& operator=(Sequence&& other)
+    Sequence &operator=(Sequence &&other)
     {
         if (this != &other) {
             seq_ = std::move(other.seq_);
@@ -83,26 +86,31 @@ struct Sequence {
         return *this;
     }
 
-    Sequence& reverse();
-    Sequence& complement();
-    Sequence& reverse_complement();
+    Sequence &reverse();
+    Sequence &complement();
+    Sequence &reverse_complement();
 
     Sequence reverse_copy() const;
     Sequence complement_copy() const;
     Sequence reverse_complement_copy() const;
-    size_t size() const { return seq_.size(); }
+    size_t size() const
+    { return seq_.size(); }
 
-    typename seq_type::iterator begin() { return seq_.begin(); }
-    typename seq_type::const_iterator cbegin() const { return seq_.cbegin(); }
-    typename seq_type::iterator end() { return seq_.end(); }
-    typename seq_type::const_iterator cend() const { return seq_.cend(); }
+    typename seq_type::iterator begin()
+    { return seq_.begin(); }
+    typename seq_type::const_iterator cbegin() const
+    { return seq_.cbegin(); }
+    typename seq_type::iterator end()
+    { return seq_.end(); }
+    typename seq_type::const_iterator cend() const
+    { return seq_.cend(); }
 
     // data
     seq_type seq_;
 };
 
-template <class T>
-Sequence<T>& Sequence<T>::reverse()
+template<class T>
+Sequence<T> &Sequence<T>::reverse()
 {
     auto begin = seq_.begin();
     auto end = seq_.end();
@@ -117,91 +125,96 @@ Sequence<T>& Sequence<T>::reverse()
     return *this;
 }
 
-template <class T>
-Sequence<T>& Sequence<T>::complement()
+template<class T>
+Sequence<T> &Sequence<T>::complement()
 {
-    for (auto& x : seq_) {
+    for (auto &x : seq_) {
         switch (x) {
-        case 'A':
-        case 'a':
-            x = 'T';
-            break;
-        case 'C':
-        case 'c':
-            x = 'G';
-            break;
-        case 'G':
-        case 'g':
-            x = 'C';
-            break;
-        case 'T':
-        case 't':
-        case 'U':
-        case 'u':
-            x = 'A';
-            break;
-        case 'N':
-        case 'n':
-            x = 'N';
-            break;
-        default:
-            break;
+            case 'A':
+            case 'a':
+                x = 'T';
+                break;
+            case 'C':
+            case 'c':
+                x = 'G';
+                break;
+            case 'G':
+            case 'g':
+                x = 'C';
+                break;
+            case 'T':
+            case 't':
+            case 'U':
+            case 'u':
+                x = 'A';
+                break;
+            case 'N':
+            case 'n':
+                x = 'N';
+                break;
+            default:
+                break;
         }
     }
     return *this;
 }
 
-template <class T>
-Sequence<T>& Sequence<T>::reverse_complement()
+template<class T>
+Sequence<T> &Sequence<T>::reverse_complement()
 {
     this->reverse().complement();
     return *this;
 }
 
-template <class T>
+template<class T>
 Sequence<T> Sequence<T>::reverse_copy() const
 {
-    return Sequence<T>{ seq_type{ seq_.crbegin(), seq_.crend() } };
+    return Sequence<T>{seq_type{seq_.crbegin(), seq_.crend()}};
 }
 
-template <class T>
+template<class T>
 Sequence<T> Sequence<T>::complement_copy() const
 {
-    Sequence<T> ret{ *this };
+    Sequence<T> ret{*this};
     ret.complement();
     return ret;
 }
 
-template <class T>
+template<class T>
 Sequence<T> Sequence<T>::reverse_complement_copy() const
 {
-    Sequence<T> ret{ seq_type{ seq_.crbegin(), seq_.crend() } };
+    Sequence<T> ret{seq_type{seq_.crbegin(), seq_.crend()}};
     ret.complement();
     return ret;
 }
 
-template <class T, class U>
-bool operator==(const Sequence<T>& lhs, const Sequence<U>& rhs)
+template<class T, class U>
+bool operator==(const Sequence<T> &lhs, const Sequence<U> &rhs)
 {
     return lhs.seq_ == rhs.seq_;
 }
 
-template <class T>
-struct strsize<Sequence<T> > {
-    static size_t size(const Sequence<T>& s) { return s.size(); }
+template<class T>
+struct strsize<Sequence<T> >
+{
+    static size_t size(const Sequence<T> &s)
+    { return s.size(); }
 };
 
-namespace std {
-template <class T>
-auto begin(Sequence<T>& s) -> decltype(s.begin())
+namespace std
+{
+template<class T>
+auto begin(Sequence<T> &s) -> decltype(s.begin())
 {
     return s.begin();
 }
 
-template <class T>
-auto begin(const Sequence<T>& s) -> decltype(s.cbegin()) const
+template<class T>
+auto begin(const Sequence<T> &s) -> decltype(s.cbegin())
+const
 {
-    return s.cbegin();
+return s.
+cbegin();
 }
 } // namespace std
 

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -77,10 +77,7 @@ private:
     iterator &iter_;
     iterator &end_;
     int size_;
-    static std::mutex mx_;
+    std::mutex mx_;
 };
-
-template<class T, template<class...> class Container>
-std::mutex MultiThreadSafeQueue<T, Container>::mx_;
 
 #endif //TRIMISOSEQPOLYA_THREAD_H

--- a/src/thread.hpp
+++ b/src/thread.hpp
@@ -34,47 +34,53 @@
 // SUCH DAMAGE.
 
 // Author: Bo Han
-#ifndef char_traits_h
-#define char_traits_h
 
-#include <string>
+#ifndef TRIMISOSEQPOLYA_THREAD_H
+#define TRIMISOSEQPOLYA_THREAD_H
 
-template<class TChar = char>
-struct CaseInsensitiveCharTrait: public std::char_traits<TChar>
+#include <mutex>
+#include "type_policy.h"
+
+/* multi-threading safe queue to produce bulk of data to process
+ * data type should
+ * 1. provide an forward_iterator to generate/obtain data from certain source
+ * container type should
+ * 1. has specialized linear_container_policy which provides "reserve" "add_to_right" "empty" policies
+ * */
+template<class T, template<class...> class Container = std::vector>
+class MultiThreadSafeQueue
 {
-    static bool eq(char c1, char c2)
-    {
-        return toupper(c1) == toupper(c2);
-    }
+public:
+    using iterator = typename T::iterator;
+    using container_type = Container<T>;
+    using policies = linear_container_policy<Container, T>;
+public:
+    MultiThreadSafeQueue(iterator &iter, iterator &end, int size)
+        : iter_(iter), end_(end), size_(size)
+    { }
 
-    static bool ne(char c1, char c2)
+    container_type get()
     {
-        return toupper(c1) != toupper(c2);
-    }
-
-    static bool lt(char c1, char c2)
-    {
-        return toupper(c1) < toupper(c2);
-    }
-
-    static int compare(const char *s1, const char *s2, size_t n)
-    {
-        for (size_t i = 0; i < n; ++i) {
-            if (toupper(*s1) < toupper(*s2))
-                return -1;
-            else if (toupper(*s1) > toupper(*s2))
-                return 1;
+        std::lock_guard<std::mutex> lock(mx_);
+        container_type ret;
+        policies::reserve(ret, size_);
+        int i;
+        for (i = 0; i < size_; ++i) {
+            if (iter_ == end_) break;
+            policies::add_to_right(ret, std::move(*iter_));
+            ++iter_;
         }
-        return 0;
+        return ret;
     }
 
-    static const char *find(const char *s, int n, char a)
-    {
-        while (n-- > 0 && toupper(*s) != toupper(a)) {
-            ++s;
-        }
-        return s; // returning \0 means not found
-    }
+private:
+    iterator &iter_;
+    iterator &end_;
+    int size_;
+    static std::mutex mx_;
 };
 
-#endif /* char_traits_h */
+template<class T, template<class...> class Container>
+std::mutex MultiThreadSafeQueue<T, Container>::mx_;
+
+#endif //TRIMISOSEQPOLYA_THREAD_H

--- a/src/type_policy.h
+++ b/src/type_policy.h
@@ -38,36 +38,146 @@
 #define type_policy_h
 
 #include <string.h>
+#include <vector>
+#include <list>
+#include <deque>
+#include <string>
 
-template <class T>
-struct read_policy {
+template<class T>
+struct read_policy
+{
 };
 
-template <class T>
-struct write_policy {
+template<class T>
+struct write_policy
+{
 };
 
 /* Sequence size calculation */
-template <class T>
-struct strsize {
+template<class T>
+struct strsize
+{
 };
 
-template <>
-struct strsize<std::string> {
-    static size_t size(const std::string& s) { return s.size(); }
+template<>
+struct strsize<std::string>
+{
+    static size_t size(const std::string &s)
+    { return s.size(); }
 };
 
-template <size_t N>
-struct strsize<char[N]> {
-    static size_t size(const char* s) { return strlen(s) /* not necessarilly N-1 */; }
+template<size_t N>
+struct strsize<char[N]>
+{
+    static size_t size(const char *s)
+    { return strlen(s) /* not necessarilly N-1 */; }
 };
 
-template <>
-struct strsize<const char*> {
-    static size_t size(const char* s) { return strlen(s); }
+template<>
+struct strsize<const char *>
+{
+    static size_t size(const char *s)
+    { return strlen(s); }
 };
 
-namespace std {
-}
+template<template<class...> class Container, class T, class... Args>
+struct linear_container_policy
+{
+};
+
+// policies for vector
+template<class T, class... Args>
+struct linear_container_policy<std::vector, T, Args...>
+{
+    using container_t = std::vector<T, Args...>;
+    using size_type = typename container_t::size_type;
+    static void reserve(container_t &c, size_type n)
+    {
+        c.reserve(n);
+    }
+
+    static void add_to_right(container_t &c, T &&item)
+    {
+        c.emplace_back(std::forward<T>(item));
+    }
+
+    static void add_to_right(container_t &c, const T &item)
+    {
+        c.push_back(item);
+    }
+
+    template<class... I>
+    static void add_to_right(container_t &c, I &&... args)
+    {
+        c.emplace_back(std::forward<I>(args)...);
+    }
+
+    static bool empty(const container_t &c)
+    {
+        return c.empty();
+    }
+};
+
+// policies for list
+template<class T, class... Args>
+struct linear_container_policy<std::list, T, Args...>
+{
+    using container_t = std::list<T, Args...>;
+    using size_type = typename container_t::size_type;
+    static void reserve(container_t &c, size_type n)
+    { /* list does not need to reserve */}
+
+    static void add_to_right(container_t &c, T &&item)
+    {
+        c.emplace_back(std::forward<T>(item));
+    }
+
+    static void add_to_right(container_t &c, const T &item)
+    {
+        c.push_back(item);
+    }
+
+    template<class... I>
+    static void add_to_right(container_t &c, I &&... args)
+    {
+        c.emplace_back(std::forward<I>(args)...);
+    }
+
+    static bool empty(const container_t &c)
+    {
+        return c.empty();
+    }
+};
+
+// policies for deque
+template<class T, class... Args>
+struct linear_container_policy<std::deque, T, Args...>
+{
+    using container_t = std::deque<T, Args...>;
+    using size_type = typename container_t::size_type;
+    static void reserve(container_t &c, size_type n)
+    { /* deque doesn't need to reserve */ }
+
+    static void add_to_right(container_t &c, T &&item)
+    {
+        c.emplace_back(std::forward<T>(item));
+    }
+
+    static void add_to_right(container_t &c, const T &item)
+    {
+        c.push_back(item);
+    }
+
+    template<class... I>
+    static void add_to_right(container_t &c, I &&... args)
+    {
+        c.emplace_back(std::forward<I>(args)...);
+    }
+
+    static bool empty(const container_t &c)
+    {
+        return c.empty();
+    }
+};
 
 #endif /* type_policy_h */


### PR DESCRIPTION
1. make multithreading queue more generic and easier to plug in different containers (vector/list/deque), which appears to have no differences in terms of speed on a typical flnc file.
2. the mutex in multithreading queue doesn't have to be static
3. fix typos in readme