### PR TITLE
make gzip/bzip2 support a CMAKE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,33 +10,35 @@ set(TrimIsoseqPolyA_MAJOR_VERSION 0)
 set(TrimIsoseqPolyA_MINOR_VERSION 0)
 set(TrimIsoseqPolyA_PATCH_VERSION 1)
 set(TrimIsoseqPolyA_VERSION
-    "${TrimIsoseqPolyA_MAJOR_VERSION}.${TrimIsoseqPolyA_MINOR_VERSION}.${TrimIsoseqPolyA_PATCH_VERSION}"
-)
+        "${TrimIsoseqPolyA_MAJOR_VERSION}.${TrimIsoseqPolyA_MINOR_VERSION}.${TrimIsoseqPolyA_PATCH_VERSION}"
+        )
 
 # build time options
 option(TrimIsoseqPolyA_build_tests "Build trim isoseq polyA unit tests." OFF)
 
 # main project paths
-set(TrimIsoseqPolyA_RootDir       ${TrimIsoseqPolyA_SOURCE_DIR})
-set(TrimIsoseqPolyA_SourceDir     ${TrimIsoseqPolyA_RootDir}/src)
-set(TrimIsoseqPolyA_TestsDir      ${TrimIsoseqPolyA_RootDir}/tests)
-set(TrimIsoseqPolyA_LibDir        ${TrimIsoseqPolyA_RootDir}/lib)
-set(TrimIsoseqPolyA_BinDir        ${TrimIsoseqPolyA_RootDir}/bin)
-file(MAKE_DIRECTORY               ${TrimIsoseqPolyA_BinDir})
+set(TrimIsoseqPolyA_RootDir ${TrimIsoseqPolyA_SOURCE_DIR})
+set(TrimIsoseqPolyA_SourceDir ${TrimIsoseqPolyA_RootDir}/src)
+set(TrimIsoseqPolyA_TestsDir ${TrimIsoseqPolyA_RootDir}/tests)
+set(TrimIsoseqPolyA_LibDir ${TrimIsoseqPolyA_RootDir}/lib)
+set(TrimIsoseqPolyA_BinDir ${TrimIsoseqPolyA_RootDir}/bin)
+file(MAKE_DIRECTORY ${TrimIsoseqPolyA_BinDir})
 
 if (NOT TrimIsoseqPolyA_OutputDir)
     set(TrimIsoseqPolyA_OutputDir ${TrimIsoseqPolyA_RootDir})
-endif()
+endif ()
 
 # shared and third-party paths
 find_package(Threads)
 find_package(Boost COMPONENTS system program_options iostreams REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-if (NOT ZLIB_LIBRARIES OR NOT ZLIB_INCLUDE_DIRS)
+option(SUPPORT_COMPRESSED_INPUT "To support gzip and bzip2 compressed input" OFF)
+if (SUPPORT_COMPRESSED_INPUT)
+    add_definitions(-DTO_SUPPORT_COMPRESSED_INPUT)
     find_package(ZLIB REQUIRED)
-endif()
-find_package(BZip2 REQUIRED)
+    find_package(BZip2 REQUIRED)
+endif ()
 
 # shared CXX flags for src & tests
 include(CheckCXXCompilerFlag)
@@ -47,12 +49,12 @@ set(TrimIsoseqPolyA_CXX_FLAGS " -g -std=c++11 -Wall")
 check_cxx_compiler_flag("-Wno-unused-local-typedefs" HAS_NO_UNUSED_LOCAL_TYPEDEF)
 if (HAS_NO_UNUSED_LOCAL_TYPEDEF)
     set(TrimIsoseqPolyA_CXX_FLAGS "${TrimIsoseqPolyA_CXX_FLAGS} -Wno-unused-local-typedefs")
-endif()
+endif ()
 
 check_cxx_compiler_flag("-Wdeprecated-declarations" HAS_DEPRECATED_DECLARATIONS)
 if (HAS_DEPRECATED_DECLARATIONS)
     set(TrimIsoseqPolyA_CXX_FLAGS "${TrimIsoseqPolyA_CXX_FLAGS} -Wdeprecated-declarations")
-endif()
+endif ()
 
 # CXX and LINKER FLAGS
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TrimIsoseqPolyA_CXX_FLAGS}")
@@ -62,7 +64,7 @@ endif()
 add_subdirectory(src)
 
 # testing
-if(TrimIsoseqPolyA_build_tests)
+if (TrimIsoseqPolyA_build_tests)
     enable_testing()
 
     # Add dependencies including gtest and gmock as external projects.
@@ -70,11 +72,11 @@ if(TrimIsoseqPolyA_build_tests)
 
     # download and build gtest
     ExternalProject_Add(
-        gtest
-        URL http://googletest.googlecode.com/files/gtest-1.7.0.zip
-        PREFIX ${CMAKE_BINARY_DIR}/gtest
-        # Disable install step
-        INSTALL_COMMAND ""
+            gtest
+            URL http://googletest.googlecode.com/files/gtest-1.7.0.zip
+            PREFIX ${CMAKE_BINARY_DIR}/gtest
+            # Disable install step
+            INSTALL_COMMAND ""
     )
 
     # Create a libgtest target to be used as a dpendency by test programs
@@ -84,28 +86,28 @@ if(TrimIsoseqPolyA_build_tests)
     # Set gtest properties
     ExternalProject_Get_Property(gtest source_dir binary_dir)
     set_target_properties(libgtest PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/libgtest.a"
-        "IMPORTED_LOCATION" "${binary_dir}/libgtest_main.a"
-        "IMPORTED_LINK_INTERFACE_LIBRARIES" ${CMAKE_THREAD_LIBS_INIT}
-    )
+            "IMPORTED_LOCATION" "${binary_dir}/libgtest.a"
+            "IMPORTED_LOCATION" "${binary_dir}/libgtest_main.a"
+            "IMPORTED_LINK_INTERFACE_LIBRARIES" ${CMAKE_THREAD_LIBS_INIT}
+            )
 
-    message (status " gtest/include = " ${source_dir}/include)
+    message(status " gtest/include = " ${source_dir}/include)
     include_directories(
-        "${source_dir}/include"
-        "${source_dir}/src"
-    ) 
-#add_subdirectory(${source_dir})
+            "${source_dir}/include"
+            "${source_dir}/src"
+    )
+    #add_subdirectory(${source_dir})
 
     #set(GTEST_SourceDir ${source_dir}) 
     #message (status " GTEST_SourceDir = " ${source_dir})
 
     # Download and build gmock
     ExternalProject_Add(
-        gmock
-        URL http://googlemock.googlecode.com/files/gmock-1.7.0.zip
-        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gmock
-        # Disable install step
-        INSTALL_COMMAND ""
+            gmock
+            URL http://googlemock.googlecode.com/files/gmock-1.7.0.zip
+            PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gmock
+            # Disable install step
+            INSTALL_COMMAND ""
     )
 
     # create a libgmock target to be used as a dependency by test programs
@@ -115,12 +117,12 @@ if(TrimIsoseqPolyA_build_tests)
     # set gmock properties
     ExternalProject_Get_Property(gmock source_dir binary_dir)
     set_target_properties(libgmock PROPERTIES
-        "IMPORTED_LOCATION" "${binary_dir}/libgmock.a"
-        "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
-    )
+            "IMPORTED_LOCATION" "${binary_dir}/libgmock.a"
+            "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+            )
 
-    message (status " gmock/include = " ${source_dir}/include)
-    include_directories("${source_dir}/include") 
+    message(status " gmock/include = " ${source_dir}/include)
+    include_directories("${source_dir}/include")
 
     add_subdirectory(tests)
-endif()
+endif ()

--- a/README.md
+++ b/README.md
@@ -7,23 +7,34 @@ with the HMM model been trained with that data. However, with an `-G` option, it
 ## Prerequisite
 - C++11
 - Boost
-- Zlib
-- BZib2
 - pthread
+- ~~Zlib~~ 
+- ~~BZib2~~ <br>
+Zlib and BZlib2 are needed if you need to support gzip/bzip2 compressed input files.
+
 
 ## Install
+
 ```bash
 mkdir build && \
 cd build && \
 cmake ../ -DBOOST_ROOT=PATH_TO_YOUR_BOOST_ROOT_DIR -DCMAKE_BUILD_TYPE=Release && \
 make
 ```
-
     Executable `trim_isoseq_polyA` will be saved in directory trim_isoseq_polyA/bin.
     Please replace PATH_TO_YOUR_BOOST_ROOT_DIR with your own boost root directory.
     e.g., -DBOOST_ROOT=~/mylib/boost/boost_1_60_0/
 
-## Build with unit tests
+#### With native support for gzip/bzip2 compressed input
+```bash
+mkdir build && \
+cd build && \
+cmake ../ -DBOOST_ROOT=PATH_TO_YOUR_BOOST_ROOT_DIR -DCMAKE_BUILD_TYPE=Release \
+    -DSUPPORT_COMPRESSED_INPUT=ON && \
+make
+```
+
+#### Build with unit tests
 ```bash
 mkdir buildwtest && \
 cd buildwtest && \

--- a/src/format.hpp
+++ b/src/format.hpp
@@ -46,9 +46,12 @@
 #include <fstream>
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
+#include "type_policy.h"
+
+#ifdef TO_SUPPORT_COMPRESSED_INPUT
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filter/bzip2.hpp>
-#include "type_policy.h"
+#endif
 
 template<class T>
 class FormatReader;
@@ -112,15 +115,19 @@ public:
                 exit(EXIT_FAILURE);
             }
             p_ist_in = new std::ifstream{file_name};
-            char magic_number[4] = "\0\0\0";
+#ifdef TO_SUPPORT_COMPRESSED_INPUT
+#define GZIP_MAGIC "\037\213"
+#define BZIP2_MAGIC "BZ"
+            char magic_number[3];
             p_ist_in->get(magic_number, 3);
-            if (magic_number[0] == '\037' && magic_number[1] == (char) '\213') {
+            if (memcmp(magic_number, GZIP_MAGIC, 2) == 0) {
                 ins_.push(boost::iostreams::gzip_decompressor());
             }
-            else if (magic_number[0] == 'B' && magic_number[1] == 'Z') {
+            else if (memcmp(magic_number, BZIP2_MAGIC, 2) == 0) {
                 ins_.push(boost::iostreams::bzip2_decompressor());
             }
             p_ist_in->seekg(0, p_ist_in->beg);
+#endif
         }
         else {
             std::ios::sync_with_stdio(false);


### PR DESCRIPTION
With `-DSUPPORT_COMPRESSED_INPUT=ON` in CMAKE, it will add support for gzip/bzip2 input