### PR TITLE
Enable cmake's add_subdirectory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 2.8)
 # project version
 set(TrimIsoseqPolyA_MAJOR_VERSION 0)
 set(TrimIsoseqPolyA_MINOR_VERSION 0)
-set(TrimIsoseqPolyA_PATCH_VERSION 1)
+set(TrimIsoseqPolyA_PATCH_VERSION 2)
 set(TrimIsoseqPolyA_VERSION
         "${TrimIsoseqPolyA_MAJOR_VERSION}.${TrimIsoseqPolyA_MINOR_VERSION}.${TrimIsoseqPolyA_PATCH_VERSION}"
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TrimIsoseqPolyA_CXX_FLAGS}")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${TrimIsoseqPolyA_EXE_LINKER_FLAGS}")
 
 add_library(trima ${LIB_SOURCE_FILES})
+
+target_include_directories(trima PUBLIC ${TrimIsoseqPolyA_SourceDir})
+
 set_target_properties(trima PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
         RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}


### PR DESCRIPTION
Without this, header are not propagated through the library trima.