### PR TITLE
Allow disabling of binary build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,13 +8,14 @@ cmake_minimum_required(VERSION 2.8)
 # project version
 set(TrimIsoseqPolyA_MAJOR_VERSION 0)
 set(TrimIsoseqPolyA_MINOR_VERSION 0)
-set(TrimIsoseqPolyA_PATCH_VERSION 2)
+set(TrimIsoseqPolyA_PATCH_VERSION 3)
 set(TrimIsoseqPolyA_VERSION
         "${TrimIsoseqPolyA_MAJOR_VERSION}.${TrimIsoseqPolyA_MINOR_VERSION}.${TrimIsoseqPolyA_PATCH_VERSION}"
         )
 
 # build time options
 option(TrimIsoseqPolyA_build_tests "Build trim isoseq polyA unit tests." OFF)
+option(TrimIsoseqPolyA_build_bin   "Build binaries." ON)
 
 # main project paths
 set(TrimIsoseqPolyA_RootDir ${TrimIsoseqPolyA_SOURCE_DIR})
@@ -98,7 +99,7 @@ if (TrimIsoseqPolyA_build_tests)
     )
     #add_subdirectory(${source_dir})
 
-    #set(GTEST_SourceDir ${source_dir}) 
+    #set(GTEST_SourceDir ${source_dir})
     #message (status " GTEST_SourceDir = " ${source_dir})
 
     # Download and build gmock

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,22 +42,24 @@ set_target_properties(trima PROPERTIES
         LIBRARY_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_LibDir}
         )
 
-add_executable(trim_isoseq_polyA ${EXE_SOURCE_FILES})
-set_target_properties(trim_isoseq_polyA PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_BinDir}
-        )
+if (TrimIsoseqPolyA_build_bin)
+        add_executable(trim_isoseq_polyA ${EXE_SOURCE_FILES})
+        set_target_properties(trim_isoseq_polyA PROPERTIES
+                RUNTIME_OUTPUT_DIRECTORY ${TrimIsoseqPolyA_BinDir}
+                )
 
-if (NOT APPLE)
-    set(MY_LIBRT -lrt)
-else ()
-endif ()
+        if (NOT APPLE)
+        set(MY_LIBRT -lrt)
+        else ()
+        endif ()
 
-message(STATUS "Boost_LIBRARIES: " ${Boost_LIBRARIES})
+        message(STATUS "Boost_LIBRARIES: " ${Boost_LIBRARIES})
 
-target_link_libraries(trim_isoseq_polyA
-        ${Boost_LIBRARIES}
-        ${ZLIB_LIBRARIES}
-        ${BZIP2_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT}
-        #${MY_LIBRT}
-        )
+        target_link_libraries(trim_isoseq_polyA
+                ${Boost_LIBRARIES}
+                ${ZLIB_LIBRARIES}
+                ${BZIP2_LIBRARIES}
+                ${CMAKE_THREAD_LIBS_INIT}
+                #${MY_LIBRT}
+                )
+endif()


### PR DESCRIPTION
This is helpful if the repo is used purely as a library.